### PR TITLE
Develop

### DIFF
--- a/src/TrixVue.vue
+++ b/src/TrixVue.vue
@@ -21,7 +21,7 @@
                       _editor = node.editor;
                   
                   if((binding.arg
-                    && binding.arg.readonly)
+                    && binding.arg === 'readonly')
                       || binding.value.readonly === true){
                         _node.contentEditable = false;
                         _node.parentNode.classList.add("trix-disabled");
@@ -36,12 +36,17 @@
                   let eventCallback = function(event) {
                         var payload;
                         if(event.attachment){
-                            payload = event.attachment;
-                            if (payload.file) {
+                            if (event.attachment.file) {
+                                  payload = {
+                                    file:event.attachment.file,
+                                    type:event.type,
+                                    target:_editor
+                                  };
+                                  
                                   if(typeof binding.value === 'function'){
-                                      return binding.value(payload, event.type);
+                                      return binding.value(payload);
                                   }else if(typeof (binding.value.events[event.type]) === 'function'){
-                                      return binding.value.events[event.type](payload, event.type);
+                                      return binding.value.events[event.type](payload);
                                   }
                             }
                         }else if(event.type){
@@ -49,11 +54,11 @@
                         }
                   }
                   
-                  if((binding.arg && binding.arg.events)
+                  if((binding.arg && binding.arg === 'events')
                       || binding.value.events instanceof Object){
                       var _events = (binding.arg === 'events')? binding.value : binding.value.events;
                       for(let event of _events){
-                          switch(event){ editor.loadJSON(JSON.parse(localStorage["editorState"]))
+                          switch(event){ 
                               case 'trix-attachment-add':
                               case 'trix-attachment-remove':
                               case 'trix-selection-change':
@@ -67,6 +72,17 @@
                               break;
                           }
                       }
+                  }
+                  
+                  if((binding.arg && binding.arg === 'savestatekey')
+                    || typeof binding.value.savestatekey === 'string'){
+                      var _key = (binding.arg === 'savestatekey')
+                      ? binding.value 
+                      : binding.value.savestatekey;
+                      
+                      _editor.loadJSON(
+                          JSON.parse(window.localStorage[_key])
+                       || '{}');
                   }
             }
         }

--- a/src/TrixVue.vue
+++ b/src/TrixVue.vue
@@ -1,18 +1,76 @@
 <template>
-  <div class="trixWrapper">
+  <div class="trix-wrapper">
     <div ref="trixContainer" :id="id">
-      <trix-editor :input="inputId"></trix-editor>
+      <trix-editor :input="inputId" :placeholder="placeholder"></trix-editor>
     </div>
   </div>
 </template>
 
 <script>
-  import 'trix';
+  import { Trix } from 'trix';
   import 'trix/dist/trix.css';
 
   export default {
     name: 'trix-vue',
+    directives:{
+        'trix-editor-options':{
+            bind(el, binding, vnode) {
+                  var _node = (el.className.indexOf('trix-wrapper') + 1)
+                                ? el.getElementsByTagName('trix-editor')[0]
+                                : el,
+                      _editor = node.editor;
+                  
+                  if((binding.arg
+                    && binding.arg.readonly)
+                      || binding.value.readonly === true){
+                        _node.contentEditable = false;
+                        _node.parentNode.classList.add("trix-disabled");
+                  }
+                  
+                  if(binding.value.attachments instanceof Object){
+                    Trix.config.attachments.preview.caption = binding.attachments.preview.caption; /*{
+                      name: false,
+                      size: false
+                  };*/
 
+                  let eventCallback = function(event) {
+                        var payload;
+                        if(event.attachment){
+                            payload = event.attachment;
+                            if (payload.file) {
+                                  if(typeof binding.value === 'function'){
+                                      return binding.value(payload, event.type);
+                                  }else if(typeof (binding.value.events[event.type]) === 'function'){
+                                      return binding.value.events[event.type](payload, event.type);
+                                  }
+                            }
+                        }else if(event.type){
+                            ;
+                        }
+                  }
+                  
+                  if((binding.arg && binding.arg.events)
+                      || binding.value.events instanceof Object){
+                      var _events = (binding.arg === 'events')? binding.value : binding.value.events;
+                      for(let event of _events){
+                          switch(event){ editor.loadJSON(JSON.parse(localStorage["editorState"]))
+                              case 'trix-attachment-add':
+                              case 'trix-attachment-remove':
+                              case 'trix-selection-change':
+                              case 'trix-change':
+                              case 'trix-initialize':
+                              case 'trix-focus':
+                              case 'trix-blur':
+                                    document.addEventListener(event, eventCallback);
+                              break;
+                              default:
+                              break;
+                          }
+                      }
+                  }
+            }
+        }
+    },
     props: {
       id: {
         type: String,
@@ -21,6 +79,10 @@
       inputId: {
         type: String,
         default: ''
+      },
+      placeholder:{
+        type: String,
+        default:'Start typing...'
       }
     },
 
@@ -30,11 +92,23 @@
     },
 
     methods: {
+        
     }
   }
 </script>
 
-<style>
+<style scoped>
   #trix-container {
+      width:auto !important;
+      min-height:200px;
+  }
+  
+  .trix-disabled .trix-editor, 
+  .trix-disabled .trix-toolbar {
+      pointer-events: none;
+  }
+
+  .trix-disabled .trix-toolbar {
+      opacity:0.45;
   }
 </style>

--- a/src/TrixVue.vue
+++ b/src/TrixVue.vue
@@ -7,8 +7,8 @@
 </template>
 
 <script>
-  import { Trix } from 'trix';
-  import 'trix/dist/trix.css';
+  import * as Trix from 'trix'
+  import 'trix/dist/trix.css'
 
   export default {
     name: 'trix-vue',
@@ -42,15 +42,18 @@
                                     type:event.type,
                                     target:_editor
                                   };
-                                  
-                                  if(typeof binding.value === 'function'){
-                                      return binding.value(payload);
-                                  }else if(typeof (binding.value.events[event.type]) === 'function'){
-                                      return binding.value.events[event.type](payload);
-                                  }
                             }
                         }else if(event.type){
-                            ;
+                            payload = {
+                                type:event.type,
+                                target:_editor
+                            };
+                        }
+                        
+                        if(typeof binding.value === 'function'){
+                            return binding.value(payload);
+                        }else if(typeof (binding.value.events[event.type]) === 'function'){
+                            return binding.value.events[event.type](payload);
                         }
                   }
                   
@@ -104,6 +107,7 @@
 
     data() {
       return {
+      
       }
     },
 


### PR DESCRIPTION
I have extended the base component using a directive **trix-editor-options** to enable certain options for the trix editor e.g.

```js
     import { TrixVue } from 'trix-vue2'
     new Vue({
           el:'#app',
           components:{ TrixVue },
           data:{
                readonly:true
           },
           method:{
                  handleInitialize:function(event, editor){
                          console.log("Trix Event type: ", event.type);
                          console.log("Trix Document: ", editor.getDocument());
                  }
           }
     });
```

```html

   <div id="app">
     <trix-vue trix-editor-options:readonly="readonly" trix-editor-options:events="{'trix-initialize':handleInitilize}">
    </div>
     </trix-vue>
```

I will like to request that if this meets your criteria, you can merge into the main branch so development can in this direction